### PR TITLE
Fix segfault when using an unknown identifier

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -353,10 +353,10 @@ static Bool parse_primary(Expression **e, Parser *p, Flag sign) {
     }
   }
 
-  fprintf(stderr, "Unknown identifier '%s'", s0);
+  fprintf(stderr, "Unknown identifier '%s'\n", s0);
   expr_free(d);
 
-  return true;
+  return false;
 }
 
 static Bool parse_top(Expression **e, Parser *p) {


### PR DESCRIPTION
For example, the `sin()` function is not yet supported, but when trying `sin(pi)` it says (with UndefinedBehaviorSanitizer enabled):

```
Unknown identifier 'sin(pi)'eval.c:452:23: runtime error: member access within misaligned address 0x1a9f07e9f100011f for type 'Expression' (aka 'struct Expression'), which requires 8 byte alignment
0x1a9f07e9f100011f: note: pointer points here
<memory cannot be printed>
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior eval.c:452:23 in
eval.c:452:23: runtime error: load of misaligned address 0x1a9f07e9f100011f for type 'enum (anonymous enum at eval.c:11:3)', which requires 8 byte alignment
0x1a9f07e9f100011f: note: pointer points here
<memory cannot be printed>
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior eval.c:452:23 in
UndefinedBehaviorSanitizer:DEADLYSIGNAL
==55692==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0xffff87e9f100011f (pc 0x0001001ed700 bp 0x0001001ed6fc sp 0x00016fc16fa0 T3060488)
==55692==The signal is caused by a UNKNOWN memory access.
    #0 0x1001ed700 in parse_verify eval.c:452

==55692==Register values:
 x[0] = 0x000000016fc16ea0   x[1] = 0x0000000000000000   x[2] = 0x0000000000000000   x[3] = 0x00000001012003d0
 x[4] = 0x6a6cb03abcebc041   x[5] = 0x0000000000000000   x[6] = 0x0000000000000000   x[7] = 0x0000000000000000
 x[8] = 0x1a9f07e9f100011f   x[9] = 0x000000000000d810  x[10] = 0x00000000000c6230  x[11] = 0x0000000000000001
x[12] = 0x0000000000000000  x[13] = 0x00000001005b7153  x[14] = 0x0000000000000000  x[15] = 0x0000000000000000
x[16] = 0x0000000000000049  x[17] = 0x0000000100410058  x[18] = 0x0000000000000000  x[19] = 0x0000000000000000
x[20] = 0x0000000000000000  x[21] = 0x0000000000000000  x[22] = 0x0000000000000000  x[23] = 0x0000000000000000
x[24] = 0x0000000000000000  x[25] = 0x0000000000000000  x[26] = 0x0000000000000000  x[27] = 0x0000000000000000
x[28] = 0x000000016fc177c8     fp = 0x000000016fc170a0     lr = 0x00000001001ed6fc     sp = 0x000000016fc16fa0
UndefinedBehaviorSanitizer can not provide additional info.
SUMMARY: UndefinedBehaviorSanitizer: SEGV eval.c:452 in parse_verify
==55692==ABORTING
```

This turns out to be due to `parse_primary()` returning `true` for unknown identifiers. Return `false` instead, and add a newline to the error message, similar to the other errors in this function.
